### PR TITLE
Fix PHPDoc indentation

### DIFF
--- a/src/Auth_Command.php
+++ b/src/Auth_Command.php
@@ -534,7 +534,9 @@ class Auth_Command extends EE_Command {
 	}
 
 	/**
-	 * Deletes http authentication for a site. Default: removes http authentication from site. If `--user` is passed it removes that specific user.
+	 * Deletes http authentication for a site.
+	 *
+	 * Default: removes http authentication from site. If `--user` is passed it removes that specific user.
 	 *
 	 * ## OPTIONS
 	 *


### PR DESCRIPTION
Required for proper description in autocomplete.

Signed-off-by: dhsathiya <devarshisathiya5@gmail.com>