### PR TITLE
Fix for ee auth delete global

### DIFF
--- a/src/Auth_Command.php
+++ b/src/Auth_Command.php
@@ -299,6 +299,12 @@ class Auth_Command extends EE_Command {
 		$site_auth_file = EE_ROOT_DIR . '/services/nginx-proxy/htpasswd/' . $site_url;
 		$this->fs->remove( $site_auth_file );
 
+		// Ensure that sites with only global auths doesn't store it in `htpasswd/site_url` file
+		$local_auths = Auth::where( 'site_url', $site_url );
+		if ( empty( $local_auths ) ) {
+			return;
+		}
+
 		$auths = array_merge(
 			Auth::get_global_auths(),
 			Auth::where( 'site_url', $site_url )


### PR DESCRIPTION
Reference #34 
## Approach
The additional code will  ensure  that if a site only have global auths , it will not be kept in separate site specific htpasswd file.

## What was causing problem
When we create a `auth` on a site then again add a `global auth` on the site , and then remove `auth` (not global) from the site, the `site specific htpasswd file` is only storing global auths which is redundant as `httpasswd/default file` will be storing it.So when we delete global `auth` from site ,  the `site specific htpasswd file` will remain as it is.So the solution was to make sure that if a site only have global `auths` , it will not be kept in separate `site specific htpasswd file`.