### PR TITLE
GH-28 Add auto remove whitelisted ips when using only `ee auth delete <sitename>`

### DIFF
--- a/src/Auth_Command.php
+++ b/src/Auth_Command.php
@@ -585,6 +585,31 @@ class Auth_Command extends EE_Command {
 
 		if ( ! $ip ) {
 			$user = EE\Utils\get_flag_value( $assoc_args, 'user' );
+
+			//When command is of the form `ee auth delete <sitename>`.
+			if ( null === $user ) {
+				EE::line( 'Auto deleting Whitelisted IPs if any...' );
+
+				$whitelists = Whitelist::where(
+					array(
+						'site_url' => $site_url,
+					)
+				);
+
+				foreach ( $whitelists as $whitelist ) {
+					$whitelist->delete();
+				}
+
+				if ( 'default' === $site_url ) {
+					$this->generate_global_whitelist();
+				} else {
+					$this->generate_site_whitelist( $site_url );
+				}
+
+				reload_global_nginx_proxy();
+
+			}
+
 			$auths = $this->get_auths( $site_url, $user );
 
 			foreach ( $auths as $auth ) {


### PR DESCRIPTION
Fixes #28 

## Approach
Since there is already a different code to handle the case when we provide `--ip` option , therefore we have to handle it in the normal case.
I have checked for a particular condition which is when user only execute  `ee auth delete <sitename>`  command. 

_**NOTE**: since it was design earlier to delete auths only , and user specific auths also , so there is possibility that user can pass a `username` , that is why we have to check for the above condition_ 

Now in this condition , we will be deleting whitelisted ips along with deleting the auths.
We have to first delete whitelisted ips if any because , it doesn't throw any error if there are no whitelisted ips already.
Deleting auths  first will hault the code execution when there are no auths on the site as it will throw a error.